### PR TITLE
build: excluir clase Main del reporte de cobertura de Jacoco

### DIFF
--- a/java-project-healthcalc/pom.xml
+++ b/java-project-healthcalc/pom.xml
@@ -77,6 +77,12 @@
                 <goals>
                     <goal>report</goal>
                 </goals>
+                <configuration>
+                  <excludes>
+                      <!-- Excluir una clase específica -->
+                      <exclude>healthcalc/Main.class</exclude>
+                  </excludes>
+                </configuration>
             </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Excluimos la clase Main del reporte de cobertura de Jacoco para asegurar un 100% en dicho reporte.