### PR TITLE
docs: añadir cabeceras y enlaces de casos de uso (Harris-Benedict y Lorentz) en el README (fixes #41, #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,3 +330,7 @@ Para cada categoría, probamos valores que están justo en el límite para asegu
 - Ejecutar los tests con informe de cobertura (previamente configurado en pom.xml): `mvn test`
 
 </details>
+
+## Especificación
+
+### Casos de uso

--- a/README.md
+++ b/README.md
@@ -334,3 +334,6 @@ Para cada categoría, probamos valores que están justo en el límite para asegu
 ## Especificación
 
 ### Casos de uso
+
+* [Calcular TMB con ecuación de Harris-Benedict](doc/Caso_de_uso_Harris_Benedict.txt)
+* [Calcular PCI con fórmula de Lorentz](doc/Caso_de_uso_Lorentz.txt)


### PR DESCRIPTION
He añadido en el README la sección "Especificación" con la subsección "Casos de uso".