### PR TITLE
docs: añadir imagen del diagrama UML y enlace caso de uso IMC en el README (closes #43, #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ Para cada categoría, probamos valores que están justo en el límite para asegu
 
 ### Casos de uso
 
+![Diagrama de casos de uso](doc/Diagrama_casos_de_uso.png)
+
 * [Calcular TMB con ecuación de Harris-Benedict](doc/Caso_de_uso_Harris_Benedict.txt)
 * [Calcular PCI con fórmula de Lorentz](doc/Caso_de_uso_Lorentz.txt)
 * [Calcular IMC](doc/Caso_de_uso_IMC.txt)

--- a/README.md
+++ b/README.md
@@ -337,3 +337,4 @@ Para cada categoría, probamos valores que están justo en el límite para asegu
 
 * [Calcular TMB con ecuación de Harris-Benedict](doc/Caso_de_uso_Harris_Benedict.txt)
 * [Calcular PCI con fórmula de Lorentz](doc/Caso_de_uso_Lorentz.txt)
+* [Calcular IMC](doc/Caso_de_uso_IMC.txt)


### PR DESCRIPTION
he añadido en el README la imagen del diagrama UML y en enlace de caso de uso del IMC en la sección de "Casos de uso"