### PR TITLE
build: configurar pom.xml para exportar aplicación a .jar (fixes #83)

### DIFF
--- a/java-project-healthcalc/pom.xml
+++ b/java-project-healthcalc/pom.xml
@@ -86,6 +86,30 @@
             </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>healthcalc.MainGUI</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
He actualizado el fichero pom.xml con el plugin maven-assembly-plugin. Ahora al hacer un mvn clean package debería de generarse el ejecutable .jar dentro de la carpeta target. Lo he probado y funciona.